### PR TITLE
Denormalize expected strings in unit tests

### DIFF
--- a/src/test/groovy/com/ceilfors/transform/gq/AutoIndentingPrintWriterTest.groovy
+++ b/src/test/groovy/com/ceilfors/transform/gq/AutoIndentingPrintWriterTest.groovy
@@ -66,6 +66,6 @@ class AutoIndentingPrintWriterTest extends Specification {
         writer.toString() ==
                 """    foonewline
                   |    barhelloworld
-                  |    gq""".stripMargin()
+                  |    gq""".stripMargin().denormalize()
     }
 }

--- a/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/ast/GqSupportTest.groovy
+++ b/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/ast/GqSupportTest.groovy
@@ -30,7 +30,7 @@ class GqSupportTest extends BaseSpecification {
 
         then:
         result == 8
-        gqFile.text == ("3 plus 5: 3 + 5=8\n")
+        gqFile.text == ("3 plus 5: 3 + 5=8\n".denormalize())
     }
 
     def "Should write method call expression statement and the evaluated expression"() {
@@ -42,6 +42,6 @@ class GqSupportTest extends BaseSpecification {
 
         then:
         result == 5
-        gqFile.text == ("nested1: nested2(value)=5\n")
+        gqFile.text == ("nested1: nested2(value)=5\n".denormalize())
     }
 }

--- a/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/ast/GqTest.groovy
+++ b/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/ast/GqTest.groovy
@@ -50,7 +50,7 @@ class GqTest extends BaseSpecification {
         example."return void"()
 
         then:
-        gqFile.text == ("return void()\n")
+        gqFile.text == ("return void()\n".denormalize())
     }
 
 
@@ -80,7 +80,7 @@ class GqTest extends BaseSpecification {
                   |  nested3()
                   |  -> 5
                   |-> 15
-                  |""".stripMargin()
+                  |""".stripMargin().denormalize()
     }
 
     def "Should write exception details if an exception is thrown"() {
@@ -96,7 +96,7 @@ class GqTest extends BaseSpecification {
         gqFile.text ==
                 """throwException()
                   |!> RuntimeException('Hello!') at GqExample.groovy:26
-                  |""".stripMargin()
+                  |""".stripMargin().denormalize()
     }
 
     def "Should write exception details if an exception is thrown from a nested method"() {
@@ -116,7 +116,7 @@ class GqTest extends BaseSpecification {
                   |    !> RuntimeException('Hello!') at GqExample.groovy:43
                   |  !> RuntimeException('Hello!') at GqExample.groovy:37
                   |!> RuntimeException('Hello!') at GqExample.groovy:31
-                  |""".stripMargin()
+                  |""".stripMargin().denormalize()
     }
 
     def "Should restore indentation when an exception is thrown"() {
@@ -138,7 +138,7 @@ class GqTest extends BaseSpecification {
                   |  nested3()
                   |  -> 5
                   |-> 15
-                  |""".stripMargin())
+                  |""".stripMargin().denormalize())
     }
 
     // --- Technical debt
@@ -151,7 +151,6 @@ class GqTest extends BaseSpecification {
     // GrabTest doesn't always grab the latest SNAPSHOT because @Grab ignores the latest SNAPSHOT in .m2. Try @zefifer grape-amaven or try @Grape's changing attribute
 
     // --- Feature
-    // Running acceptance test in Windows will break due to \n in test
     // Adopt @zefifier groovy-decorator
     // When gq file is deleted, gq won't create the file again. This is because of the convert to Writer.
     // @Gq Exception - Print source code context e.g. source code snippets and line numbers


### PR DESCRIPTION
So can assert against log with platform-specific line separator.
