### PR TITLE
Increase usability by adding default imports.

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -12,9 +12,8 @@ This file must be moved to github issue tracker once we hit 0.1.0
 - 0.1.0 Exception when gq(gq(5))
 
 # Feature
+- 0.1.0 Support for / and |
 - 0.1.0 @Gq Exception - Test - nestedException1 catch exception from nestedexception2 and throw again. Indentation must stay the same.
-- 0.1.0 Colouring in console. Ability to turn it off.
-- 0.1.0 Move @Gq out of ast package to gq.gq.
 - @Gq Exception - Print source code context e.g. source code snippets and line numbers
 - @Gq(vars=true) to print all variable expression
 - GqSupport - Support removing comments from expression text e.g. // in multiline or /* */ in one liner

--- a/src/main/groovy/com/ceilfors/transform/gq/Gq.groovy
+++ b/src/main/groovy/com/ceilfors/transform/gq/Gq.groovy
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-package com.ceilfors.transform.gq.ast
+package com.ceilfors.transform.gq
 
 import com.github.yihtserns.groovy.decorator.MethodDecorator
 import org.codehaus.groovy.transform.GroovyASTTransformationClass
-
-import com.ceilfors.transform.gq.ExceptionInfo
-import com.ceilfors.transform.gq.MethodInfo
-import com.ceilfors.transform.gq.SingletonCodeFlowManager
 
 import java.lang.annotation.ElementType
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
 import java.lang.annotation.Target
-
 /**
  * @author ceilfors
  */

--- a/src/main/groovy/com/ceilfors/transform/gq/ast/AutoImportASTTransformation.groovy
+++ b/src/main/groovy/com/ceilfors/transform/gq/ast/AutoImportASTTransformation.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Wisen Tanasa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ceilfors.transform.gq.ast
+
+import com.ceilfors.transform.gq.Gq
+import com.ceilfors.transform.gq.GqSupport
+import org.codehaus.groovy.ast.ASTNode
+import org.codehaus.groovy.ast.ClassHelper
+import org.codehaus.groovy.control.CompilePhase
+import org.codehaus.groovy.control.SourceUnit
+import org.codehaus.groovy.transform.ASTTransformation
+import org.codehaus.groovy.transform.GroovyASTTransformation
+
+/**
+ * @author ceilfors
+ */
+@GroovyASTTransformation(phase = CompilePhase.CONVERSION)
+class AutoImportASTTransformation implements ASTTransformation {
+
+    @Override
+    void visit(ASTNode[] astNodes, SourceUnit sourceUnit) {
+        sourceUnit.getAST().addImport("gt", ClassHelper.make(Gq))
+        sourceUnit.getAST().addStaticImport(ClassHelper.make(GqSupport), "gq", "gq")
+    }
+}

--- a/src/main/resources/META-INF/services/org.codehaus.groovy.transform.ASTTransformation
+++ b/src/main/resources/META-INF/services/org.codehaus.groovy.transform.ASTTransformation
@@ -15,3 +15,4 @@
 #
 
 com.ceilfors.transform.gq.ast.GqSupportTransformation
+com.ceilfors.transform.gq.ast.AutoImportASTTransformation

--- a/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/GqExample.groovy
+++ b/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/GqExample.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.ceilfors.transform.gq.ast
+package com.ceilfors.transform.gq
 
 /**
  * @author ceilfors

--- a/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/ast/BaseSpecification.groovy
+++ b/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/ast/BaseSpecification.groovy
@@ -69,9 +69,7 @@ class BaseSpecification extends Specification {
 
 
     static insertPackageAndImport(String text) {
-        return """package com.ceilfors.transform.gq.ast
-                 |
-                 |import static com.ceilfors.transform.gq.GqSupport.gq
+        return """package com.ceilfors.groovy.test
                  |
                  |$text""".stripMargin()
     }

--- a/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/ast/CompileStaticTest.groovy
+++ b/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/ast/CompileStaticTest.groovy
@@ -59,7 +59,7 @@ class CompileStaticTest extends BaseSpecification {
     def "Gq should be able to be used in conjunction with CompileStatic method"() {
         setup:
         def instance = toInstance(wrapMethodInClass("""
-            @Gq
+            @gt
             @groovy.transform.CompileStatic
             public String compileStatic() {
                 return "static!"
@@ -80,7 +80,7 @@ class CompileStaticTest extends BaseSpecification {
         def instance = toInstance(insertPackageAndImport("""
             @groovy.transform.CompileStatic
             class Test {
-                @Gq
+                @gt
                 public String compileStatic() {
                     return "static!"
                 }

--- a/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/ast/GqTest.groovy
+++ b/test-acceptance/src/test/groovy/com/ceilfors/transform/gq/ast/GqTest.groovy
@@ -16,6 +16,8 @@
 
 package com.ceilfors.transform.gq.ast
 
+import com.ceilfors.transform.gq.GqExample
+
 import static com.ceilfors.groovy.spock.FileComparisonHelper.fileContentEquals
 
 class GqTest extends BaseSpecification {
@@ -23,7 +25,7 @@ class GqTest extends BaseSpecification {
     def "Should write the name of a method with empty parameter"() {
         setup:
         def instance = toInstance(wrapMethodInClass("""
-            @Gq
+            @gt
             int "return 5"() {
                 5
             }
@@ -40,7 +42,7 @@ class GqTest extends BaseSpecification {
     def "Should write the returned value of a method call"() {
         setup:
         def instance = toInstance(wrapMethodInClass("""
-            @Gq
+            @gt
             int "return 5"() {
                 5
             }
@@ -57,7 +59,7 @@ class GqTest extends BaseSpecification {
     def "Should write the arguments of a method call"() {
         setup:
         def instance = toInstance(wrapMethodInClass("""
-            @Gq
+            @gt
             int add(int x, int y) {
                 return x + y
             }
@@ -74,7 +76,7 @@ class GqTest extends BaseSpecification {
     def "Should be able to write a method when its return type is void"() {
         setup:
         def instance = toInstance(wrapMethodInClass("""
-            @Gq
+            @gt
             void "return void"() {}
         """))
 
@@ -88,9 +90,9 @@ class GqTest extends BaseSpecification {
     def "Should write nested method call with indentation"() {
         setup:
         def instance = toInstance(wrapMethodInClass("""
-            @Gq int nested()          { nested2() + 5 }
+            @gt int nested()          { nested2() + 5 }
                 private int nested2() { nested3() + 5 }
-            @Gq private int nested3() { 5 }
+            @gt private int nested3() { 5 }
         """))
 
         when:
@@ -167,7 +169,7 @@ class GqTest extends BaseSpecification {
     def "Should be able to be used in standalone Groovy script"() {
         setup:
         def instance = toInstance(insertPackageAndImport("""
-            @Gq
+            @gt
             def simplyReturn(arg) { arg }
 
             simplyReturn(5)
@@ -186,7 +188,7 @@ class GqTest extends BaseSpecification {
     def "Should shorten long expression and save the original expression to a temporary file"() {
         setup:
         def instance = toInstance(wrapMethodInClass("""
-            @Gq
+            @gt
             String simplyReturn(arg) {
                 return arg
             }

--- a/test-color/src/main/groovy/com/ceilfors/groovy/gq/visualizeColor.groovy
+++ b/test-color/src/main/groovy/com/ceilfors/groovy/gq/visualizeColor.groovy
@@ -16,13 +16,10 @@
 
 package com.ceilfors.groovy.gq
 
-import com.ceilfors.transform.gq.ast.Gq
-import static com.ceilfors.transform.gq.GqSupport.gq
-
 /**
  * @author ceilfors
  */
-@Gq
+@gt
 String hello() {
     try {
        oops()
@@ -30,7 +27,7 @@ String hello() {
     shout("hello ") + gq(scream("world"))
 }
 
-@Gq
+@gt
 String shout(String message) {
     return message.toUpperCase()
 }
@@ -39,7 +36,7 @@ String scream(String message) {
     return gq(message) + "!!!"
 }
 
-@Gq
+@gt
 String oops() {
     throw new RuntimeException('Hello')
 }

--- a/test-integration-grab/src/test/groovy/com/ceilfors/transform/gq/ast/GrabTest.groovy
+++ b/test-integration-grab/src/test/groovy/com/ceilfors/transform/gq/ast/GrabTest.groovy
@@ -51,8 +51,6 @@ class GrabTest {
 
         def test = new GroovyClassLoader().parseClass("""
 
-            import static com.ceilfors.transform.gq.GqSupport.gq
-
             @Grab(group='${artifactGroup}', module='${artifactModule}', version='${artifactVersion}')
             class GrabTest {
 


### PR DESCRIPTION
@gt and gq() are made available automatically without import.
